### PR TITLE
fix: footer styling for small device screen

### DIFF
--- a/src/components/Footer/styled.tsx
+++ b/src/components/Footer/styled.tsx
@@ -97,10 +97,13 @@ export const ALinkIcon = styled.a`
 
 export const LogoBox = styled.div`
   display: grid;
-  justify-content: end;
+  justify-content: center;
   margin-bottom: ${({ theme }) => rem(theme.pulsar.size.house)};
   margin-top: ${({ theme }) => rem(theme.pulsar.size.house)};
-  padding-right: ${({ theme }) => rem(theme.pulsar.size.closet)};
+  @media (min-width: ${rem(mobileScreen)}) {
+    justify-content: end;
+    padding-right: ${({ theme }) => rem(theme.pulsar.size.closet)};
+  }
 `;
 
 export const MediaRow = styled.div`


### PR DESCRIPTION
=before=
![image](https://user-images.githubusercontent.com/42575132/105454839-87b08900-5cbd-11eb-81eb-cacad92238ac.png)


=after=
![210122_2](https://user-images.githubusercontent.com/42575132/105456833-cf84df80-5cc0-11eb-9462-f418b41816e2.jpg)
