### PR TITLE
fix: 'recent swaps' crashed

### DIFF
--- a/src/modules/scenes/Main/Explorer/TxHistories/index.tsx
+++ b/src/modules/scenes/Main/Explorer/TxHistories/index.tsx
@@ -186,10 +186,10 @@ export const TxHistories = (props: Props) => {
                 </Column>
                 <Column>
                   <Top>
-                    <AddressP>{tx.addressIn.toLowerCase()}</AddressP>
+                    <AddressP>{tx.addressIn?.toLowerCase()}</AddressP>
                   </Top>
                   <Bottom>
-                    <AddressP>{tx.addressOut.toLowerCase()}</AddressP>
+                    <AddressP>{tx.addressOut?.toLowerCase()}</AddressP>
                   </Bottom>
                 </Column>
                 <ColumnAmount>


### PR DESCRIPTION
Fix the `recent swaps` crash issue