### PR TITLE
fix: Use hardcoding TVL temporary

### DIFF
--- a/src/modules/explorer/utils/network/index.tsx
+++ b/src/modules/explorer/utils/network/index.tsx
@@ -1,8 +1,7 @@
 import { CoinSymbol } from '../../../coins';
 import { sumArray } from '../../../common';
-import { ENDPOINT_ETHEREUM_NODE, ENDPOINT_COINGECKO } from '../../../env';
+import { ENDPOINT_COINGECKO, ENDPOINT_ETHEREUM_NODE } from '../../../env';
 import { fetch } from '../../../fetch';
-import { fetchNodeList } from '../../../metanodes';
 import { IFloat, IFloatAmount, IFloatBalances, IMetanode, IStats } from '../../index';
 
 export const getUsdPrice = async (currency: string): Promise<number> => {
@@ -65,13 +64,16 @@ export const fetchStatsInfo = async (): Promise<IStats> => {
         ethereumBridge,
       ),
       fetch<[]>(ethereumBridgePeers),
-      fetchNodeList(),
+      // Memo: Enable after endpoint has be applied cache
+      // fetchNodeList(),
     ]);
     const ethereumRes = results[0].ok && results[0].response;
     const ethereumPeersRes = results[1].ok && results[1].response;
-    const nodeList = results[2] as IMetanode[];
+    // Memo: Enable after endpoint has be applied cache
+    // const nodeList = results[2] as IMetanode[];
+    // const tvl = calTvl(nodeList);
 
-    const tvl = calTvl(nodeList);
+    const tvl = 47729160;
     const rewards1wksSWINGBY = Number((tvl * 0.01).toFixed(0));
 
     const volume1wksWBTC: number = sumArray(ethereumRes.network24hrSwapsVolume.slice(0, 8));


### PR DESCRIPTION
Hardcode TVL(temporary) to avoid `peer` endpoint unsalable issue.

<img width="508" alt="Screenshot 2021-02-25 at 8 26 22 PM" src="https://user-images.githubusercontent.com/42575132/109291157-98779000-7863-11eb-9449-b5327b033086.png">
