### PR TITLE
fix: make eth bridge as default bridge for metanode page

### DIFF
--- a/src/modules/scenes/Main/Metanodes/BrowserMetanodes/index.tsx
+++ b/src/modules/scenes/Main/Metanodes/BrowserMetanodes/index.tsx
@@ -46,7 +46,7 @@ export const BrowserMetanodes = () => {
             <BridgeMetanodes bridge={bridge} setBridge={setBridge} />
           </Left>
           <Right>
-            {bridge === btcErc ? <MetanodeInfo bridge={bridge} /> : <h1>COMING SOON</h1>}
+            {bridge && bridge !== btcErc ? <h1>COMING SOON</h1> : <MetanodeInfo bridge={bridge} />}
           </Right>
         </BrowserMetanodesDiv>
       </BrowserMetanodesContainer>


### PR DESCRIPTION
Before: https://gyazo.com/8a678f2472643a4b0509595b22a8500b