### PR TITLE
fix: condition for open widget

### DIFF
--- a/src/modules/hooks/useLinkToWidget/index.tsx
+++ b/src/modules/hooks/useLinkToWidget/index.tsx
@@ -52,7 +52,7 @@ export const useLinkToWidget = (data: IData) => {
   }, [dispatch]);
 
   useEffect(() => {
-    if (tx) {
+    if (tx && toggleOpenLink > 1) {
       // Memo: Widget config for ETH bridge
       const widget =
         action === 'claim'


### PR DESCRIPTION
Modified bug for automatically called 'login' when open the detail page.

Before:
https://gyazo.com/626c21dc9148dd4ad921f38795137267