### PR TITLE
feat: use VWAP USD price for SWINGBY and BTC

### DIFF
--- a/src/modules/common/utils/calculation/index.spec.ts
+++ b/src/modules/common/utils/calculation/index.spec.ts
@@ -1,59 +1,7 @@
-import { calculateVwap, sumArray } from './index';
+import { sumArray } from './index';
 
 const testArray = [2, 3, 2];
 
-// Ref: https://api.coingecko.com/api/v3/coins/swingby/market_chart?days=7&vs_currency=usd&interval=daily
-// Memo: Swingby price data during 12 ~ 19 Apr
-const marketData = {
-  prices: [
-    [1618272000000, 0.6376374439310816],
-    [1618358400000, 0.5964655126950319],
-    [1618444800000, 0.5841401464354775],
-    [1618531200000, 0.5936151705493641],
-    [1618617600000, 0.5290959128857052],
-    [1618704000000, 0.5503873092964819],
-    [1618798792000, 0.49890316306011556],
-  ],
-  market_caps: [
-    [1618272000000, 78570442.46562156],
-    [1618358400000, 73475050.9209529],
-    [1618444800000, 71564602.77511482],
-    [1618531200000, 73148518.76311317],
-    [1618617600000, 65220292.40518636],
-    [1618704000000, 68067381.49116817],
-    [1618798792000, 61877384.47817382],
-  ],
-  total_volumes: [
-    [1618272000000, 3154746.1738124317],
-    [1618358400000, 2838639.332763009],
-    [1618444800000, 2192213.544554478],
-    [1618531200000, 1296902.9798534887],
-    [1618617600000, 3184390.524800979],
-    [1618704000000, 1961657.6372040757],
-    [1618798792000, 2584033.895684095],
-  ],
-};
 it('return network name', () => {
   expect(sumArray(testArray)).toStrictEqual(7);
-});
-
-it('test VWAP ', () => {
-  expect(
-    calculateVwap([
-      [5, 10],
-      [13, 8.5],
-      [10, 11],
-    ]),
-  ).toStrictEqual(9.660714285714286);
-  expect(
-    calculateVwap([
-      [marketData.total_volumes[0][1], marketData.prices[0][1]],
-      [marketData.total_volumes[1][1], marketData.prices[1][1]],
-      [marketData.total_volumes[2][1], marketData.prices[2][1]],
-      [marketData.total_volumes[3][1], marketData.prices[3][1]],
-      [marketData.total_volumes[4][1], marketData.prices[4][1]],
-      [marketData.total_volumes[5][1], marketData.prices[5][1]],
-      [marketData.total_volumes[6][1], marketData.prices[6][1]],
-    ]),
-  ).toStrictEqual(0.5698655175704712);
 });

--- a/src/modules/explorer/index.ts
+++ b/src/modules/explorer/index.ts
@@ -33,7 +33,7 @@ export {
   getFloatBalance,
   getBaseEndpoint,
   getFixedBaseEndpoint,
-  getVwap,
+  fetchVwap,
 } from './utils';
 
 export const selectableBridge = [

--- a/src/modules/explorer/utils/index.ts
+++ b/src/modules/explorer/utils/index.ts
@@ -22,7 +22,7 @@ export {
   fetchFloatBalances,
   fetchStatsInfo,
   getUsdPrice,
-  getVwap,
+  fetchVwap,
   getEndpoint,
   getFixedBaseEndpoint,
   castToBackendVariable,

--- a/src/modules/explorer/utils/network/index.tsx
+++ b/src/modules/explorer/utils/network/index.tsx
@@ -101,7 +101,7 @@ export const getUsdPrice = async (currency: string): Promise<number> => {
   return Number(price);
 };
 
-export const getVwap = async (currency: 'btcUsd' | 'swingbyUsd'): Promise<number> => {
+export const fetchVwap = async (currency: 'btcUsd' | 'swingbyUsd'): Promise<number> => {
   const url = `${CACHED_ENDPOINT}/v1/vwap-prices`;
   const res = await fetcher<{
     btcUsd: string;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -4,7 +4,7 @@ import { useDispatch } from 'react-redux';
 
 import { Layout } from '../components/Layout';
 import { NoServiceToUSModal } from '../components/NoServiceToUSModal';
-import { getVwap, IFetchUsd } from '../modules/explorer';
+import { fetchVwap, IFetchUsd } from '../modules/explorer';
 import { getIpInfoFromRequest } from '../modules/ip-info';
 import { Main } from '../modules/scenes';
 import { fetchUsdPrice } from '../modules/store';
@@ -33,7 +33,7 @@ export default function Home({ shouldBlockIp, initialPriceUSD }: Props) {
 export const getServerSideProps: GetServerSideProps<Props> = async ({ req }) => {
   const initialPriceUSD = await (async (): Promise<IFetchUsd> => {
     try {
-      const results = await Promise.all([getVwap('btcUsd'), getVwap('swingbyUsd')]);
+      const results = await Promise.all([fetchVwap('btcUsd'), fetchVwap('swingbyUsd')]);
       const priceUSD = {
         BTC: results[0],
         SWINGBY: results[1],

--- a/src/pages/pool.tsx
+++ b/src/pages/pool.tsx
@@ -4,7 +4,7 @@ import { useDispatch } from 'react-redux';
 
 import { Layout } from '../components/Layout';
 import { NoServiceToUSModal } from '../components/NoServiceToUSModal';
-import { IFetchUsd, getVwap } from '../modules/explorer';
+import { IFetchUsd, fetchVwap } from '../modules/explorer';
 import { getIpInfoFromRequest } from '../modules/ip-info';
 import { Main } from '../modules/scenes';
 import { fetchUsdPrice } from '../modules/store';
@@ -33,7 +33,7 @@ export default function Pool({ shouldBlockIp, initialPriceUSD }: Props) {
 export const getServerSideProps: GetServerSideProps<Props> = async ({ req }) => {
   const initialPriceUSD = await (async (): Promise<IFetchUsd> => {
     try {
-      const results = await Promise.all([getVwap('btcUsd'), getVwap('swingbyUsd')]);
+      const results = await Promise.all([fetchVwap('btcUsd'), fetchVwap('swingbyUsd')]);
 
       const priceUSD = {
         BTC: results[0],


### PR DESCRIPTION
* Use VWAP (7days) to fetch SWINGBY and BTC price.  (to make it less volatile) 

![image](https://user-images.githubusercontent.com/42575132/115571071-3b430c80-a2f1-11eb-9520-62a79a556561.png)

