### PR TITLE
fix: roll back interface for fetching /bonded-historic

### DIFF
--- a/src/modules/hooks/useToggleMetanode/index.tsx
+++ b/src/modules/hooks/useToggleMetanode/index.tsx
@@ -5,6 +5,7 @@ import { IChartDate } from '../../explorer';
 import { fetcher } from '../../fetch';
 import {
   fetchNodeList,
+  IBondHistories,
   IChurn,
   ILiquidity,
   ILiquidityRatio,
@@ -12,7 +13,6 @@ import {
   INodeListResponse,
   IReward,
   listHistory,
-  TBondHistory,
 } from '../../metanodes';
 import { useInterval } from '../useInterval';
 import { useToggleBridge } from '../useToggleBridge';
@@ -33,8 +33,7 @@ export const useToggleMetanode = (path: PATH) => {
       const rewardsUrl = `${ENDPOINT_SKYBRIDGE_EXCHANGE}/${mode}/${bridge}/rewards-last-week`;
       const result = await fetcher<IReward>(rewardsUrl);
       setReward(result);
-    }
-    if (bridge && path === PATH.ROOT) {
+    } else if (bridge && path === PATH.ROOT) {
       const rewardsUrl = `${ENDPOINT_SKYBRIDGE_EXCHANGE}/${mode}/${bridge}/rewards-last-week`;
       const rewardData = await fetcher<IReward>(rewardsUrl);
       setReward(rewardData);
@@ -76,8 +75,8 @@ export const useToggleMetanode = (path: PATH) => {
   const getBondHistory = useCallback(async () => {
     if (bridge && path === PATH.METANODES) {
       const url = `${ENDPOINT_SKYBRIDGE_EXCHANGE}/${mode}/${bridge}/bonded-historic`;
-      const result = await fetcher<TBondHistory[]>(url);
-      const bondHistoriesData = result;
+      const result = await fetcher<IBondHistories>(url);
+      const bondHistoriesData = result.data;
       const listBondHistory = listHistory(bondHistoriesData).reverse();
       setBondHistories(listBondHistory);
     }

--- a/src/modules/metanodes/utils/index.tsx
+++ b/src/modules/metanodes/utils/index.tsx
@@ -1,6 +1,6 @@
 import { SkybridgeBridge } from '@swingby-protocol/sdk';
 
-import { INodeListResponse, INodeStatusTable, TBondHistory } from '..';
+import { IBondHistories, INodeListResponse, INodeStatusTable, TBondHistory } from '..';
 import { getShortDate } from '../../common';
 import { ENDPOINT_SKYBRIDGE_EXCHANGE, mode } from '../../env';
 import { IChartDate } from '../../explorer';
@@ -179,18 +179,19 @@ export const getLockedHistory = async (bridge: SkybridgeBridge) => {
     const urlBtcEth = `${ENDPOINT_SKYBRIDGE_EXCHANGE}/production/btc_erc/bonded-historic`;
     const urlBtcBsc = `${ENDPOINT_SKYBRIDGE_EXCHANGE}/production/btc_bep20/bonded-historic`;
 
-    const results = await Promise.all([
-      fetcher<TBondHistory[]>(urlBtcEth),
-      fetcher<TBondHistory[]>(urlBtcBsc),
-    ]);
-
     if (bridge === 'btc_erc') {
-      return formatHistoriesArray(results[0]);
+      const result = await fetcher<IBondHistories>(urlBtcEth);
+      return formatHistoriesArray(result.data);
     } else if (bridge === 'btc_bep20') {
-      return formatHistoriesArray(results[1]);
+      const result = await fetcher<IBondHistories>(urlBtcBsc);
+      return formatHistoriesArray(result.data);
     } else {
-      const lockedHistoryEth = formatHistoriesArray(results[0]);
-      const lockedHistoryBsc = formatHistoriesArray(results[1]);
+      const results = await Promise.all([
+        fetcher<IBondHistories>(urlBtcEth),
+        fetcher<IBondHistories>(urlBtcBsc),
+      ]);
+      const lockedHistoryEth = formatHistoriesArray(results[0].data);
+      const lockedHistoryBsc = formatHistoriesArray(results[1].data);
       const mergedArray = mergeLockedArray(lockedHistoryEth, lockedHistoryBsc);
 
       // Memo: Remove duplicated 'at'

--- a/src/modules/network-stats/index.ts
+++ b/src/modules/network-stats/index.ts
@@ -6,7 +6,7 @@ import { sumArray } from '../common';
 import { ENDPOINT_BSC_BRIDGE, ENDPOINT_ETHEREUM_BRIDGE, ENDPOINT_SKYBRIDGE_EXCHANGE } from '../env';
 import { castToBackendVariable, getFloatBalance, getUsdPrice, IFloatAmount } from '../explorer';
 import { fetcher } from '../fetch';
-import { INodeListResponse, TBondHistory } from '../metanodes';
+import { IBondHistories, INodeListResponse } from '../metanodes';
 
 export const getNodeQty = async (): Promise<string> => {
   const getbridgePeersUrl = (bridge: SkybridgeBridge) =>
@@ -71,16 +71,16 @@ export const getTVL = async (): Promise<string> => {
     const results = await Promise.all([
       fetcher<IFloatAmount[]>(getFloatBalUrl(ENDPOINT_ETHEREUM_BRIDGE)),
       fetcher<IFloatAmount[]>(getFloatBalUrl(ENDPOINT_BSC_BRIDGE)),
-      fetcher<TBondHistory[]>(getBondBalUrl('btc_erc')),
-      fetcher<TBondHistory[]>(getBondBalUrl('btc_bep20')),
+      fetcher<IBondHistories>(getBondBalUrl('btc_erc')),
+      fetcher<IBondHistories>(getBondBalUrl('btc_bep20')),
       getUsdPrice('bitcoin'),
     ]);
 
     const resEth = results[0];
     const resBsc = results[1];
 
-    const tvlSwingbyEth = Number(results[2][0].bond);
-    const tvlSwingbyBsc = Number(results[3][0].bond);
+    const tvlSwingbyEth = Number(results[2].data[0].bond);
+    const tvlSwingbyBsc = Number(results[3].data[0].bond);
 
     const usdBtc = results[4];
 

--- a/src/modules/scenes/Main/Metanodes/MetanodeList/index.tsx
+++ b/src/modules/scenes/Main/Metanodes/MetanodeList/index.tsx
@@ -1,10 +1,10 @@
 import { getCryptoAssetFormatter, Tooltip, useMatchMedia } from '@swingby-protocol/pulsar';
 import { SkybridgeBridge } from '@swingby-protocol/sdk';
+import { hasFlag } from 'country-flag-icons';
 import { DateTime } from 'luxon';
 import { rem } from 'polished';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { useSelector } from 'react-redux';
-import { hasFlag } from 'country-flag-icons';
 
 import { PATH } from '../../../../env';
 import { convertDateTime, getDiffDays } from '../../../../explorer';
@@ -53,9 +53,8 @@ interface Props {
 export const MetanodeList = (props: Props) => {
   const { locale } = useIntl();
   const { metanodes, bridge, isLoading } = props;
-  const { tvl } = useGetBridgesTvl(PATH.METANODES);
+  const { tvl } = useGetBridgesTvl(PATH.METANODES, bridge);
   const usd = useSelector((state) => state.explorer.usd);
-  const tvlUsd = tvl[bridge];
   const swingbyRewardCurrency = 'BEP2';
   const sbBTCRewardCurrency = bridge && getSbBtcRewardCurrency(bridge);
 
@@ -106,7 +105,7 @@ export const MetanodeList = (props: Props) => {
             const expireTimestamp = dt.toSeconds();
             const expireTime = convertDateTime(expireTimestamp);
             const lockedUsdValue = Number(node.bondAmount) * usd.SWINGBY;
-            const lockedPortion = Number((lockedUsdValue / tvlUsd) * 100).toFixed(2);
+            const lockedPortion = Number((lockedUsdValue / tvl) * 100).toFixed(2);
 
             const isNoRequiredTooltip =
               xl || node.status === 'churned-in' || node.status === 'may-churn-in';
@@ -157,7 +156,7 @@ export const MetanodeList = (props: Props) => {
                 </SizeL>
                 <div>
                   <TextRoom>{bondAmount}</TextRoom>{' '}
-                  {tvlUsd > 0 && <TextRoom variant="label">({lockedPortion}%)</TextRoom>}
+                  {tvl > 0 && <TextRoom variant="label">({lockedPortion}%)</TextRoom>}
                 </div>
                 <ColumnExpiry>
                   <Column>


### PR DESCRIPTION
* roll back interface for fetching /bonded-historic
* fetch /rewards-last-week faster (fetch only match the bridge endpoint rather than fetch 2 bridges in same time)