### PR TITLE
fix: add 'Farm' link into header

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -17,7 +17,7 @@ export const Header = () => {
   const items = useMemo(
     () => [
       {
-        key: 'farm',
+        key: 'farms',
         render: 'Farms',
         href: URL.YieldFarming,
         target: '_blank',


### PR DESCRIPTION
Link to https://farm.swingby.network/
![image](https://user-images.githubusercontent.com/42575132/126596746-eca6b5c2-c65d-46fa-985e-4c8c6a38b6b0.png)
