### PR TITLE
fix: show loading animation when nodes API is broken

### DIFF
--- a/src/modules/scenes/Main/Explorer/NetworkBridges/index.tsx
+++ b/src/modules/scenes/Main/Explorer/NetworkBridges/index.tsx
@@ -90,7 +90,8 @@ export const NetworkBridges = () => {
     <PulseLoader margin={3} size={4} color={theme.pulsar.color.text.normal} />
   );
 
-  const isLoadingAll = isLoadingTvl || isLoading;
+  // Memo: Show 'loading' animation if backend api is broken
+  const isLoadingAll = isLoadingTvl || isLoading || floatBalances.btcEth === 0;
   const placeholderLoaderTvl = (
     <RowLoader>
       <PulseLoader margin={3} size={2} color={theme.pulsar.color.text.masked} />

--- a/src/modules/scenes/Main/Explorer/StatsInfo/index.tsx
+++ b/src/modules/scenes/Main/Explorer/StatsInfo/index.tsx
@@ -56,7 +56,8 @@ export const StatsInfo = () => {
     isLoading: isLoadingGetChart,
   } = useGetStatsChartData();
 
-  const isLoadingAll = isLoading || isLoadingMetanode || isLoadingGetChart;
+  const isLoadingAll =
+    isLoading || isLoadingMetanode || isLoadingGetChart || stats.volume1wksBTC === 0;
   const placeholderLoader = (
     <PulseLoader margin={3} size={4} color={theme.pulsar.color.text.normal} />
   );


### PR DESCRIPTION
Show loading animation when backend (node) endpoint is broken. (Rather than shows `0` in UI)

=Before=
![image](https://user-images.githubusercontent.com/42575132/126992830-617e9fb6-9b4e-44a2-a9ef-50ed1422cba5.png)

=After=
![image](https://user-images.githubusercontent.com/42575132/126992707-5b414f27-b784-4a6a-984f-02ce7c81c6b1.png)
