### PR TITLE
fix: load walletconnect bridge url from environment variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,4 @@ NEXT_PUBLIC_BSC_SCAN_KEY = "apikey"
 NEXT_PUBLIC_ETHER_SCAN_KEY = "apikey"
 NEXT_PUBLIC_BLOCKNATIVE_KEY = 'apikey'
 NEXT_PUBLIC_INFURA_KEY = 'apikey'
+NEXT_PUBLIC_WC_BRIDGE = 'https://wallet-bridge.binance.org/'

--- a/src/modules/env/index.ts
+++ b/src/modules/env/index.ts
@@ -94,3 +94,5 @@ export const bscscanApiKey = process.env.NEXT_PUBLIC_BSC_SCAN_KEY;
 export const blocknativeApiKey = process.env.NEXT_PUBLIC_BLOCKNATIVE_KEY;
 
 export const infuraApiKey = process.env.NEXT_PUBLIC_INFURA_KEY;
+
+export const WC_BRIDGE = process.env.NEXT_PUBLIC_WC_BRIDGE;

--- a/src/modules/onboard/customWallet/customWalletConnect/index.ts
+++ b/src/modules/onboard/customWallet/customWalletConnect/index.ts
@@ -1,6 +1,6 @@
 import WalletConnectProvider from '@walletconnect/web3-provider';
 import { CommonWalletOptions, Helpers, WalletModule } from 'bnc-onboard/dist/src/interfaces'; // eslint-disable-line
-import { infuraApiKey } from '../../../env';
+import { infuraApiKey, WC_BRIDGE } from '../../../env';
 
 import { walletConnectLogo } from './logo';
 
@@ -17,13 +17,12 @@ export function customWalletConnect(
     wallet: async () => {
       const POLLING_INTERVAL = 12000;
       const bscRpcUrl = 'https://bsc-dataseed1.binance.org:443';
-      const bridge = 'https://pancakeswap.bridge.walletconnect.org/';
       const provider = new WalletConnectProvider({
         rpc: {
           1: `https://mainnet.infura.io/v3/${infuraApiKey}`,
           56: bscRpcUrl,
         },
-        bridge,
+        bridge: WC_BRIDGE,
         pollingInterval: POLLING_INTERVAL,
         chainId: networkId,
       });


### PR DESCRIPTION
* Get 'wallet connect' bridge URL from environment variable since bridge url has been broken sometime (URL from pancake or binance)

![image](https://user-images.githubusercontent.com/42575132/129011290-9bce194a-ec6f-4ebd-b1a2-1b171d5ff906.png)
