### PR TITLE
fix: add space between APR and % value in Metanode page

### DIFF
--- a/src/modules/scenes/Main/Metanodes/ActionButtonMetanodes/index.tsx
+++ b/src/modules/scenes/Main/Metanodes/ActionButtonMetanodes/index.tsx
@@ -19,7 +19,9 @@ export const ActionButtonMetanodes = () => {
         <TextTitle variant="accent">
           <FormattedMessage id="pool.apr" />
         </TextTitle>
-        <TextAPR variant="accent">{apr}%</TextAPR>
+        <TextAPR variant="accent">
+          <FormattedMessage id="common.percent" values={{ value: ' ' + apr }} />
+        </TextAPR>
       </RowText>
       <ButtonContainer>
         <RewardButton />


### PR DESCRIPTION
Fixed typo