### PR TITLE
fix: show dot if data is only contain Pending value in Earned chart

### DIFF
--- a/src/modules/scenes/Main/Pool/EarningStats/EarningsChart/index.tsx
+++ b/src/modules/scenes/Main/Pool/EarningStats/EarningsChart/index.tsx
@@ -122,11 +122,11 @@ export const EarningsChart = ({ farming, bridge }) => {
         </Column>
       </TitleDiv>
       {pendingSwingby > 0 || claimedSwingby > 0 ? (
-        <ResponsiveContainer width={chartWidth} height="100%">
+        <ResponsiveContainer width={chartWidth} height={182}>
           <AreaChart
             data={chartData}
             margin={{
-              top: 24,
+              top: 20,
               right: 6,
               left: -30,
               bottom: 4,


### PR DESCRIPTION
=Before=
Missing dot if 'data' doesn't have 'claimed' value.

![image](https://user-images.githubusercontent.com/42575132/134329804-c674edc0-3f5b-4de8-885d-64e2a075315e.png)

=After=
![image](https://user-images.githubusercontent.com/42575132/134329629-9e595003-2587-487a-b145-c29a39e98c64.png)
