### PR TITLE
fix: avoid crashing without passing bridge parameter in pool path

### DIFF
--- a/src/modules/scenes/Main/Pool/FarmCard/index.tsx
+++ b/src/modules/scenes/Main/Pool/FarmCard/index.tsx
@@ -60,7 +60,7 @@ export const FarmCard = () => {
                         values={{
                           value: (
                             <FormattedNumber
-                              value={apr[bridge].sbBtc}
+                              value={bridge && apr[bridge].sbBtc}
                               maximumFractionDigits={2}
                               minimumFractionDigits={2}
                             />
@@ -75,7 +75,7 @@ export const FarmCard = () => {
                         values={{
                           value: (
                             <FormattedNumber
-                              value={apr[bridge].farm}
+                              value={bridge && apr[bridge].farm}
                               maximumFractionDigits={2}
                               minimumFractionDigits={2}
                             />


### PR DESCRIPTION
Fix the bug that app crashes without passing bridge parameter to pool page. ( https://skybridge.info/pool )