### PR TITLE
fix: time format (Avoid rendering time such as '24:XX'

### DIFF
--- a/src/modules/explorer/utils/transaction/index.tsx
+++ b/src/modules/explorer/utils/transaction/index.tsx
@@ -119,7 +119,7 @@ export const convertDateTime = (unixTimestamp: number) => {
       year="numeric"
       month="short"
       day="2-digit"
-      hour12={false}
+      hourCycle="h23"
     />
   );
 };


### PR DESCRIPTION
=Before=
![image](https://user-images.githubusercontent.com/42575132/135959466-fc12efa4-e6b8-4e8b-9df0-78a4d59a1712.png)


=After=
![image](https://user-images.githubusercontent.com/42575132/135959490-a722eda5-fecc-4826-8531-de039473c2ea.png)
