### PR TITLE
[UI] Skybridge swap WBTC to BTC swap link is not working

### DIFF
--- a/src/modules/coins/index.tsx
+++ b/src/modules/coins/index.tsx
@@ -23,8 +23,8 @@ export const EthereumWalletAddressCoins = [
   CoinSymbol.SKYPOOL_WBTC,
 ];
 
-export const ETHCoins = [CoinSymbol.ERC20_SB_BTC, CoinSymbol.WBTC];
-export const BTCCoins = [CoinSymbol.BTC, CoinSymbol.SKYPOOL_WBTC];
+export const ETHCoins = [CoinSymbol.ERC20_SB_BTC, CoinSymbol.WBTC, CoinSymbol.SKYPOOL_WBTC];
+export const BTCCoins = [CoinSymbol.BTC];
 
 export const getBridgeBtc = (bridge: SkybridgeBridge): CoinSymbol => {
   switch (bridge) {

--- a/src/modules/scenes/Main/Metanodes/BridgeMetanodes/index.tsx
+++ b/src/modules/scenes/Main/Metanodes/BridgeMetanodes/index.tsx
@@ -30,7 +30,7 @@ export const BridgeMetanodes = () => {
             <TextBridge variant="accent" isActive={bridge === b.bridge}>
               {b.tabMenu}
             </TextBridge>
-            <IconRight/>
+            <IconRight />
           </RowBridge>
         );
       })}

--- a/src/modules/scenes/Main/SwapRewards/BrowserSwapRewards/index.tsx
+++ b/src/modules/scenes/Main/SwapRewards/BrowserSwapRewards/index.tsx
@@ -2,7 +2,7 @@ import { Text } from '@swingby-protocol/pulsar';
 import { SkybridgeBridge, SKYBRIDGE_BRIDGES } from '@swingby-protocol/sdk';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
-import React, { useEffect, useMemo } from 'react';
+import React, { useMemo } from 'react';
 import { FormattedMessage, FormattedNumber } from 'react-intl';
 
 import { ConnectWalletMini } from '../../../../../components/ConnectWalletMini';

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,7 +1,7 @@
 import { ApolloClient, ApolloProvider, InMemoryCache } from '@apollo/client';
 import { relayStylePagination } from '@apollo/client/utilities'; // eslint-disable-line import/no-internal-modules
 import { RouterScrollProvider } from '@moxy/next-router-scroll';
-import { createToast, Text } from '@swingby-protocol/pulsar';
+import { createToast } from '@swingby-protocol/pulsar';
 import { useRouter } from 'next/router';
 import { useEffect, useMemo } from 'react';
 import { FormattedMessage, IntlProvider } from 'react-intl';

--- a/src/pages/api/v1/sbbtc-apr.ts
+++ b/src/pages/api/v1/sbbtc-apr.ts
@@ -5,7 +5,6 @@ import { NextApiRequest, NextApiResponse } from 'next';
 import { corsMiddleware, getParam } from '../../../modules/api';
 import { sumArray } from '../../../modules/common';
 import { fetcher } from '../../../modules/fetch';
-
 import {
   fetchFloatBalances,
   fetchVwap,


### PR DESCRIPTION
Closes #241

### What's new

- Move SKYPOOL_WBTC to ETHCoins to generate the right link

### How to test

- Run it locally
- Go to http://localhost:3000/swap/kHTG1yFARUY6Qgy-6vKKeQGy9FCOM7gUe-bHBh_8kYY=
- Click on "info" icon, and you should see the WBTC transaction on Etherscan